### PR TITLE
fix draft chip position

### DIFF
--- a/web/lib/components/item-box.tsx
+++ b/web/lib/components/item-box.tsx
@@ -143,7 +143,7 @@ const ItemBox = () => {
         <Box sx={{ textAlign: 'right' }}>
           {
             draft ?
-              <Chip label="draft" color="warning" sx={{ float: 'right' }} /> : dataUser ?
+              <Chip label="draft" color="warning" /> : dataUser ?
                 (
                   <Chip
                     avatar={(


### PR DESCRIPTION
This pull request includes a small change to the `ItemBox` component in `web/lib/components/item-box.tsx`. The change removes the `float: 'right'` style from the "draft" `Chip` component.