### PR TITLE
update default shape styles

### DIFF
--- a/web/default-shape-styles.json
+++ b/web/default-shape-styles.json
@@ -14,7 +14,7 @@
     "polylines": {
         "normal": {
             "strokeColor": "#f09d38",
-            "strokeOpacity": 0.6,
+            "strokeOpacity": 0.8,
             "strokeWeight": 2,
             "zIndex": 30
         },


### PR DESCRIPTION
This pull request includes a small change to the `web/default-shape-styles.json` file. The change updates the `strokeOpacity` value for polylines in the "normal" style from `0.6` to `0.8`, enhancing the visibility of polylines.