### PR TITLE
change item path

### DIFF
--- a/web/app/show/[id]/page.tsx
+++ b/web/app/show/[id]/page.tsx
@@ -1,0 +1,44 @@
+import ItemBox from "../../../lib/components/item-box"
+import { getItemAction } from "../../lib/walk-actions"
+import ItemFetcher from "@/lib/utils/item-fetcher"
+
+export default async function Page() {
+  return (
+    <>
+      <ItemFetcher />
+      <ItemBox /> 
+    </>
+  )
+}
+
+export async function generateMetadata({params}: {params: Promise<{ id: string }>}) {
+  const getItemState = {
+    error: null,
+    idTokenExpired: false,
+    curernt: null,
+    serial: 0,
+  }
+  const { id } = await params
+  const newState = await getItemAction(getItemState, Number(id))
+  if (!newState.current) {
+    return {}
+  }
+  const item = newState.current
+  const title = `${item.date} : ${item.title} (${item.length.toFixed(1)} km)`
+  const description = item.comment && (`${item.comment.replace(/[\n\r]/g, '').substring(0, 140)}...`)
+  const image = item.image
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url: `/show/${id}`,
+      images: image ? [
+        {
+          url: image,
+        },
+      ] : [],
+    },
+  }
+}

--- a/web/app/walk/[id]/page.tsx
+++ b/web/app/walk/[id]/page.tsx
@@ -1,44 +1,7 @@
-import ItemBox from "../../../lib/components/item-box"
-import { getItemAction } from "../../lib/walk-actions"
-import ItemFetcher from "@/lib/utils/item-fetcher"
+import { redirect } from 'next/navigation'
 
-export default async function Page() {
-  return (
-    <>
-      <ItemFetcher />
-      <ItemBox /> 
-    </>
-  )
-}
-
-export async function generateMetadata({params}: {params: Promise<{ id: string }>}) {
-  const getItemState = {
-    error: null,
-    idTokenExpired: false,
-    curernt: null,
-    serial: 0,
-  }
+export default async function Page({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
-  const newState = await getItemAction(getItemState, Number(id))
-  if (!newState.current) {
-    return {}
-  }
-  const item = newState.current
-  const title = `${item.date} : ${item.title} (${item.length.toFixed(1)} km)`
-  const description = item.comment && (`${item.comment.replace(/[\n\r]/g, '').substring(0, 140)}...`)
-  const image = item.image
-  return {
-    title,
-    description,
-    openGraph: {
-      title,
-      description,
-      url: `/walk/${id}`,
-      images: image ? [
-        {
-          url: image,
-        },
-      ] : [],
-    },
-  }
+  redirect(`/show/${id}`)
 }
+

--- a/web/lib/components/bottom-bar.test.tsx
+++ b/web/lib/components/bottom-bar.test.tsx
@@ -24,7 +24,7 @@ jest.mock('../utils/config', () => ({
 
 jest.mock('next/navigation', () => ({
   useSearchParams: jest.fn(() => new URLSearchParams()),
-  usePathname: jest.fn(() => '/walk/1'),
+  usePathname: jest.fn(() => '/show/1'),
 }))
 
 jest.mock('use-query-params', () => ({

--- a/web/lib/components/main.tsx
+++ b/web/lib/components/main.tsx
@@ -45,7 +45,7 @@ const Main = ({
   const shareCB = useCallback(async () => {
     try {
       const origin = window.location.origin
-      const url = `${origin}${current ? '/walk/' + current.id : '/?' + window.location.search} `
+      const url = `${origin}${current ? '/show/' + current.id : '/?' + window.location.search} `
       const text = document.title
       if (navigator.share) {
         await navigator.share({ url, text })

--- a/web/lib/components/map.test.tsx
+++ b/web/lib/components/map.test.tsx
@@ -44,7 +44,7 @@ jest.mock('use-query-params', () => ({
 
 jest.mock('next/navigation', () => ({
   useSearchParams: jest.fn(() => new URLSearchParams({ filter: 'cities', cities: '123' })),
-  usePathname: jest.fn(() => '/walk/1'),
+  usePathname: jest.fn(() => '/show/1'),
   useRouter: jest.fn(() => ({
     push: jest.fn(),
     replace: jest.fn(),

--- a/web/lib/components/search-box.test.tsx
+++ b/web/lib/components/search-box.test.tsx
@@ -81,7 +81,7 @@ describe('SearchBox', () => {
     ])
 
     render(<SearchBox />)
-    expect(mockRouterReplace).toHaveBeenCalledWith(expect.stringContaining('/walk/1'))
+    expect(mockRouterReplace).toHaveBeenCalledWith(expect.stringContaining('/show/1'))
   })
 
   it('displays "No results" when count is 0', () => {

--- a/web/lib/components/walk-editor.test.tsx
+++ b/web/lib/components/walk-editor.test.tsx
@@ -97,7 +97,7 @@ describe('WalkEditor update', () => {
     fireEvent.click(screen.getByTestId('submit-button'))
     expect(submitSpy).toHaveBeenCalled()
     expect(mockSetOpened).toHaveBeenCalledWith(false)
-    expect(mockRouterPush).not.toHaveBeenCalledWith('/walk/2')
+    expect(mockRouterPush).not.toHaveBeenCalledWith('/show/2')
 
   })
 
@@ -146,7 +146,7 @@ describe('WalkEditor create', () => {
     fireEvent.click(screen.getByTestId('submit-button'))
     expect(submitSpy).toHaveBeenCalled()
     expect(mockSetOpened).toHaveBeenCalledWith(false)
-    expect(mockRouterPush).toHaveBeenCalledWith('/walk/2')
+    expect(mockRouterPush).toHaveBeenCalledWith('/show/2')
 
   })
 

--- a/web/lib/components/walk-editor.tsx
+++ b/web/lib/components/walk-editor.tsx
@@ -19,6 +19,7 @@ import { useQueryParam, StringParam, withDefault } from 'use-query-params';
 import { useRouter } from 'next/navigation';
 import { useUserContext } from '../utils/user-context';
 import { useMapContext } from '../utils/map-context';
+import { idToUrl } from '../utils/meta-utils'
 
 const WalkEditor = ({ item, opened, setOpened }) => {
   const router = useRouter()
@@ -60,7 +61,7 @@ const WalkEditor = ({ item, opened, setOpened }) => {
         if (item?.id) {
           reset()
         } else if (state.id) {
-          router.push(`/walk/${state.id}`)
+          router.push(idToUrl(state.id));
         }
       }
     }

--- a/web/lib/utils/meta-utils.ts
+++ b/web/lib/utils/meta-utils.ts
@@ -6,6 +6,6 @@ export const getTitles = (config, item) => {
   return titles
 }
 
-export const idToUrl = (id, params: URLSearchParams = null) => `/walk/${id}${params ? `?${params.toString()}` : ''}`
+export const idToUrl = (id, params: URLSearchParams = null) => `/show/${id}${params ? `?${params.toString()}` : ''}`
 
 export const getCanonical = (config, data) => config.baseUrl + (data ? idToUrl(data.id) : '/')


### PR DESCRIPTION
This pull request updates the routing structure by replacing `/walk` paths with `/show` paths across the codebase. It also introduces improvements to metadata generation and refactors related components and utilities.

### Routing Updates:
* [`web/lib/utils/meta-utils.ts`](diffhunk://#diff-c06dd09f35c3d323f5fb4373eba67b8c2e2894d2a0e52bb982a994c592be59ecL9-R9): Changed `idToUrl` utility function to generate `/show` paths instead of `/walk` paths.
* [`web/lib/components/main.tsx`](diffhunk://#diff-7d107aac4d3e1f9bdfd585fb3cb9bcaf1b6ce16f621cbee694caff5ca0fcd915L48-R48): Updated the `shareCB` callback to use `/show` paths for sharing URLs.
* Test files (`web/lib/components/bottom-bar.test.tsx`, `web/lib/components/map.test.tsx`, `web/lib/components/search-box.test.tsx`, `web/lib/components/walk-editor.test.tsx`): Updated mocked `usePathname` calls and assertions to use `/show` paths instead of `/walk` paths. [[1]](diffhunk://#diff-7eff85f709c4d8c7b2807563fc82bbf25ef923bd8f5ce563860b77e82c5e162cL27-R27) [[2]](diffhunk://#diff-f7a7119428f2edb4695b6af26d9218637e5b965903dd7b0599dae86002db0086L47-R47) [[3]](diffhunk://#diff-6ebe45fb7ad1ac1d67fb7c681c6b4e404cb08781a9b6b026e841c702b7eafae8L84-R84) [[4]](diffhunk://#diff-a6684c27a44cf90d47f011a35fa734db827ed27b2f394afe881a156a0a342cceL100-R100) [[5]](diffhunk://#diff-a6684c27a44cf90d47f011a35fa734db827ed27b2f394afe881a156a0a342cceL149-R149)

### Metadata Generation:
* `web/app/show/[id]/page.tsx`: Added a new metadata generation function that creates dynamic Open Graph tags based on the item details. ([web/app/show/[id]/page.tsxR1-R44](diffhunk://#diff-589a0d9b8d327e6f0d813d6abf2b22ab7f002aef5106ae543f056753c6bde488R1-R44))
* `web/app/walk/[id]/page.tsx`: Removed the metadata generation function and replaced the page logic with a redirect to `/show/[id]`. ([web/app/walk/[id]/page.tsxL1-R7](diffhunk://#diff-069d2e03b6731bc041286a85e14ce377abdc3d00492f622fc48fe63c82bf92daL1-R7))

### Component Refactoring:
* [`web/lib/components/walk-editor.tsx`](diffhunk://#diff-f6a7bc7f771fc4409e8314cc21a74f25ea097d5f1d54e3ae1195b5ba98ad2dbdR22): Refactored `WalkEditor` to use the updated `idToUrl` utility for routing. [[1]](diffhunk://#diff-f6a7bc7f771fc4409e8314cc21a74f25ea097d5f1d54e3ae1195b5ba98ad2dbdR22) [[2]](diffhunk://#diff-f6a7bc7f771fc4409e8314cc21a74f25ea097d5f1d54e3ae1195b5ba98ad2dbdL63-R64)