### PR TITLE
use nullish coalescing operator

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -6,8 +6,8 @@ import type { Viewport } from 'next'
 export const viewport: Viewport = {
 
   themeColor: [
-    { media: '(prefers-color-scheme: light)', color: process.env.THEME_COLOR_LIGHT || process.env.THEME_COLOR || '#ffffff' },
-    { media: '(prefers-color-scheme: dark)', color: process.env.THEME_COLOR_DARK || process.env.THEME_COLOR || '#000000' },
+    { media: '(prefers-color-scheme: light)', color: process.env.THEME_COLOR_LIGHT ?? process.env.THEME_COLOR ?? '#ffffff' },
+    { media: '(prefers-color-scheme: dark)', color: process.env.THEME_COLOR_DARK ?? process.env.THEME_COLOR ?? '#000000' },
   ],
 }
 
@@ -38,7 +38,7 @@ export default function RootLayout({
 
 export const metadata: Metadata = {
   title: {
-    template: `%s | ${process.env.SITE_NAME || 'Walklog'}`,
-    default: process.env.SITE_NAME || 'Walklog',
+    template: `%s | ${process.env.SITE_NAME ?? 'Walklog'}`,
+    default: process.env.SITE_NAME ?? 'Walklog',
   },
 }

--- a/web/app/lib/walk-actions.test.ts
+++ b/web/app/lib/walk-actions.test.ts
@@ -696,13 +696,13 @@ describe('getConfig', () => {
 
     expect(result).toEqual({
       googleApiKey: process.env.GOOGLE_API_KEY,
-      googleApiVersion: process.env.GOOGLE_API_VERSION || 'weekly',
+      googleApiVersion: process.env.GOOGLE_API_VERSION ?? 'weekly',
       openUserMode: false,
       appVersion: process.env.npm_package_version,
       defaultCenter: process.env.DEFAULT_CENTER,
-      defaultZoom: parseInt(process.env.DEFAULT_ZOOM || '12', 10),
+      defaultZoom: parseInt(process.env.DEFAULT_ZOOM ?? '12', 10),
       defaultRadius: 500,
-      mapTypeIds: process.env.MAP_TYPE_IDS || 'roadmap,hybrid,satellite,terrain',
+      mapTypeIds: process.env.MAP_TYPE_IDS ?? 'roadmap,hybrid,satellite,terrain',
       mapId: process.env.MAP_ID,
       firebaseConfig: mockFirebaseConfig,
       theme: mockTheme,
@@ -716,6 +716,6 @@ describe('getConfig', () => {
     })
 
     await expect(getConfig()).rejects.toThrow('File read error')
-    expect(fs.readFileSync).toHaveBeenCalledWith(process.env.SHAPE_STYLES_JSON || './default-shape-styles.json')
+    expect(fs.readFileSync).toHaveBeenCalledWith(process.env.SHAPE_STYLES_JSON ?? './default-shape-styles.json')
   })
 })

--- a/web/app/lib/walk-actions.ts
+++ b/web/app/lib/walk-actions.ts
@@ -25,20 +25,20 @@ const loadFirebaseConfig = () => {
 
 export const getConfig = async (): Promise<ConfigT> => {
   'use cache'
-  const shapeStylesContent = fs.readFileSync(process.env.SHAPE_STYLES_JSON || './default-shape-styles.json')
+  const shapeStylesContent = fs.readFileSync(process.env.SHAPE_STYLES_JSON ?? './default-shape-styles.json')
   const shapeStyles = JSON.parse(shapeStylesContent.toString())
-  const themeContent = fs.readFileSync(process.env.THEME_JSON || './default-theme.json')
+  const themeContent = fs.readFileSync(process.env.THEME_JSON ?? './default-theme.json')
   const theme = JSON.parse(themeContent.toString())
   if (!firebaseConfig) loadFirebaseConfig()
   return {
     googleApiKey: process.env.GOOGLE_API_KEY,
-    googleApiVersion: process.env.GOOGLE_API_VERSION || 'weekly',
+    googleApiVersion: process.env.GOOGLE_API_VERSION ?? 'weekly',
     openUserMode: !!process.env.OPEN_USER_MODE,
     appVersion: process.env.npm_package_version,
     defaultCenter: process.env.DEFAULT_CENTER,
-    defaultZoom: parseInt(process.env.DEFAULT_ZOOM || '12', 10),
+    defaultZoom: parseInt(process.env.DEFAULT_ZOOM ?? '12', 10),
     defaultRadius: 500,
-    mapTypeIds: process.env.MAP_TYPE_IDS || 'roadmap,hybrid,satellite,terrain',
+    mapTypeIds: process.env.MAP_TYPE_IDS ?? 'roadmap,hybrid,satellite,terrain',
     mapId: process.env.MAP_ID,
     firebaseConfig,
     shapeStyles,
@@ -63,7 +63,7 @@ const getUid = async (state) => {
   try {
     const claim = await admin.auth()
       .verifyIdToken(idToken.value)
-    return [claim?.uid, claim?.admin || false]
+    return [claim?.uid, claim?.admin ?? false]
   } catch (error) {
     if (error.code === 'auth/id-token-expired') {
       state.idTokenExpired = true
@@ -96,7 +96,7 @@ export const searchInternalAction = async (props: SearchProps, uid: string): Pro
   }
 
   const where = []
-  const order = orderHash[props.order || 'newest_first']
+  const order = orderHash[props.order ?? 'newest_first']
 
   if (props.date) {
     where.push({ date: props.date })
@@ -112,8 +112,8 @@ export const searchInternalAction = async (props: SearchProps, uid: string): Pro
   }
   if (['neighborhood', 'start', 'end'].includes(props.filter as string)) {
     const c = props.center.split(/,/)
-    const latitude = parseFloat(c[0]) || 0
-    const longitude = parseFloat(c[1]) || 0
+    const latitude = parseFloat(c[0]) ?? 0
+    const longitude = parseFloat(c[1]) ?? 0
     const radius = parseFloat(props.radius as string)
     const dlat = (radius * 180) / Math.PI / EARTH_RADIUS
     const mlat = latitude > 0 ? latitude + dlat : latitude - dlat
@@ -166,7 +166,7 @@ export const searchInternalAction = async (props: SearchProps, uid: string): Pro
       state.rows = []
       return state
     }
-    const maxDistance = props.max_distance || 4000
+    const maxDistance = props.max_distance ?? 4000
     const linestring = Walk.decodePath(props.path as string)
     const extent = Walk.getPathExtent(props.path as string)
     const dlat = (maxDistance * 180) / Math.PI / EARTH_RADIUS
@@ -190,7 +190,7 @@ export const searchInternalAction = async (props: SearchProps, uid: string): Pro
       state.rows = []
       return state
     }
-    const maxDistance = props.max_distance || 4000
+    const maxDistance = props.max_distance ?? 4000
     const linestring = Walk.decodePath(props.path as string)
     const sp = Walk.getStartPoint(props.path as string)
     const ep = Walk.getEndPoint(props.path as string)
@@ -225,8 +225,8 @@ export const searchInternalAction = async (props: SearchProps, uid: string): Pro
     where.push({ draft: false })
   }
 
-  const limit = props.limit || 20
-  const offset = props.offset || 0
+  const limit = props.limit ?? 20
+  const offset = props.offset ?? 0
 
   const condition = { [Op.and]: where }
   const result = await Walk.findAndCountAll({
@@ -264,7 +264,7 @@ export const getItemInternalAction = async (id: number, uid: string): Promise<Ge
     return state
   }
   
-  state.current = (!walk.draft || walk.uid === uid) ? walk.asObject(true) : null
+  state.current = (!walk.draft ?? walk.uid === uid) ? walk.asObject(true) : null
   return state
 }
 
@@ -309,7 +309,7 @@ export const updateItemAction = async (prevState: UpdateItemState, formData, _ge
   const walkPath = formData.get('path')
   const draft = formData.get('draft') === 'true' ? true : false
   const willDeleteImage = formData.get('will_delete_image') === 'true' ? true : false
-  if (!title || !date) {
+  if (!title ?? !date) {
     state.error = new Error('Title, date are required.')
     return state
   }
@@ -330,8 +330,8 @@ export const updateItemAction = async (prevState: UpdateItemState, formData, _ge
   }
   if (willDeleteImage) {
     props.image = null
-  } else if ((image?.size || 0) > 0) {
-    const prefix = process.env.IMAGE_PREFIX || 'images'
+  } else if ((image?.size ?? 0) > 0) {
+    const prefix = process.env.IMAGE_PREFIX ?? 'images'
     const filePath = path.join(prefix, getFilename(id, image))
     const content = await image.arrayBuffer()
     const buffer = Buffer.from(content)
@@ -420,7 +420,7 @@ export const getUsersAction = async (): Promise<UserT[]> => {
   const userResult = await admin.auth().listUsers(1000)
   return userResult.users.map((user) => {
     const { uid, displayName, photoURL } = user
-    const admin = user.customClaims?.admin || false
+    const admin = user.customClaims?.admin ?? false
     return { uid, displayName, photoURL, admin }
   })
 }

--- a/web/app/lib/walk-actions.ts
+++ b/web/app/lib/walk-actions.ts
@@ -264,7 +264,7 @@ export const getItemInternalAction = async (id: number, uid: string): Promise<Ge
     return state
   }
   
-  state.current = (!walk.draft ?? walk.uid === uid) ? walk.asObject(true) : null
+  state.current = (!walk.draft || walk.uid === uid) ? walk.asObject(true) : null
   return state
 }
 
@@ -309,7 +309,7 @@ export const updateItemAction = async (prevState: UpdateItemState, formData, _ge
   const walkPath = formData.get('path')
   const draft = formData.get('draft') === 'true' ? true : false
   const willDeleteImage = formData.get('will_delete_image') === 'true' ? true : false
-  if (!title ?? !date) {
+  if (!title || !date) {
     state.error = new Error('Title, date are required.')
     return state
   }
@@ -420,7 +420,7 @@ export const getUsersAction = async (): Promise<UserT[]> => {
   const userResult = await admin.auth().listUsers(1000)
   return userResult.users.map((user) => {
     const { uid, displayName, photoURL } = user
-    const admin = user.customClaims?.admin ?? false
+    const admin = user.customClaims?.admin || false
     return { uid, displayName, photoURL, admin }
   })
 }

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,7 +1,7 @@
 import SearchBox from "@/lib/components/search-box";
 import type { Metadata } from 'next'
 import Searcher from "@/lib/utils/searcher";
-const description = process.env.SITE_DESCRIPTION || ''
+const description = process.env.SITE_DESCRIPTION ?? ''
 
 export const metadata: Metadata = {
   description,

--- a/web/lib/components/bottom-bar.tsx
+++ b/web/lib/components/bottom-bar.tsx
@@ -153,11 +153,11 @@ const BottomBar = (props) => {
     <div key="item">
       <Box sx={sxBottomBarGroupBody}>
         <Tooltip title="prev" placement="top">
-          <IconButton data-testid="prev-button" disabled={!prevUrl} component={Link} href={prevUrl || ''} size="large"><NavigationArrowBack /></IconButton>
+          <IconButton data-testid="prev-button" disabled={!prevUrl} component={Link} href={prevUrl ?? ''} size="large"><NavigationArrowBack /></IconButton>
         </Tooltip>
         <Typography variant="body1" sx={{ display: 'inline', flexShrink: 1 }} noWrap>{title}</Typography>
         <Tooltip title="next" placement="top">
-          <IconButton data-testid="next-button" disabled={!nextUrl} component={Link} href={nextUrl || ''} size="large"><NavigationArrowForward /></IconButton>
+          <IconButton data-testid="next-button" disabled={!nextUrl} component={Link} href={nextUrl ?? ''} size="large"><NavigationArrowForward /></IconButton>
         </Tooltip>
       </Box>
     </div>

--- a/web/lib/components/elevation-box.tsx
+++ b/web/lib/components/elevation-box.tsx
@@ -77,7 +77,7 @@ const ElevationBox = () => {
   }, [selectedItem, mapLoaded])
   
   if (selectedItem && chartData.length > 0) {
-    const strokeColor = config?.shapeStyles?.polylines?.current?.strokeColor || '#82ca9d'
+    const strokeColor = config?.shapeStyles?.polylines?.current?.strokeColor ?? '#82ca9d'
     
     return (
       <div data-testid="elevation-box" style={{ width: '100%', height: '20vh' }}>
@@ -99,7 +99,7 @@ const ElevationBox = () => {
             <Tooltip
               content={({ active, payload }: { active: boolean, payload: TooltipPayload[]}) => {
                 
-                handleTooltipChange(active || false, payload)
+                handleTooltipChange(active ?? false, payload)
                 return null // カスタムツールチップは使わず、Google Maps InfoWindowを使用
               }}
             />

--- a/web/lib/components/item-box.tsx
+++ b/web/lib/components/item-box.tsx
@@ -83,7 +83,7 @@ const ItemBox = () => {
   const itemWillRender = !data.isPending && item
   const title = itemWillRender ? `${item.date} : ${item.title} (${item.length.toFixed(1)} km)` : ''
   const image = item?.image
-  const dataUser = users.find((u: UserT) => u.uid === item?.uid) || null
+  const dataUser = users.find((u: UserT) => u.uid === item?.uid) ?? null
   const upUrl = `/?${searchParams.toString()}`
   const draft = item?.draft
   let nextUrl = data.nextId && idToShowUrl(data.nextId, searchParams)
@@ -118,15 +118,15 @@ const ItemBox = () => {
     <Box data-testid="ItemBox">
       <Paper sx={{ width: '100%', textAlign: 'center', padding: 2 }}>
         <Fab sx={{ float: 'left', marginLeft: 1, marginTop: 1 }} size="small" color="primary" component={Link} href={upUrl}><ListIcon /></Fab>
-        <IconButton disabled={!prevUrl} component={Link} href={prevUrl || ''} size="large"><NavigationArrowBackIcon /></IconButton>
-        <IconButton disabled={!nextUrl} component={Link} href={nextUrl || ''} size="large"><NavigationArrowForwardIcon /></IconButton>
+        <IconButton disabled={!prevUrl} component={Link} href={prevUrl ?? ''} size="large"><NavigationArrowBackIcon /></IconButton>
+        <IconButton disabled={!nextUrl} component={Link} href={nextUrl ?? ''} size="large"><NavigationArrowForwardIcon /></IconButton>
         {
           currentUser && item.uid && currentUser.uid === item.uid ? (<IconButton component={Link} href={idToEditUrl(item?.id, searchParams)} size="large" data-testid="edit-button"><EditIcon /></IconButton>) : null
         }
         {
           currentUser && item.uid && currentUser.uid === item.uid ? (<IconButton disabled={isPending} onClick={handleDelete} size="large" data-testid="delete-button"><DeleteIcon /></IconButton>) : null
         }
-        <Typography variant="h6" sx={{ fontSize: '100%' }}>{title || 'not found'}</Typography>
+        <Typography variant="h6" sx={{ fontSize: '100%' }}>{title ?? 'not found'}</Typography>
         <Box sx={{ textAlign: 'right' }}>
           {
             draft ?
@@ -174,7 +174,7 @@ const ItemBox = () => {
               },
             }}
           >
-            <ReactMarkdown>{item?.comment || ''}</ReactMarkdown>
+            <ReactMarkdown>{item?.comment ?? ''}</ReactMarkdown>
           </Typography>
         </TabPanel>
         <TabPanel value={tabValue} index={1}>

--- a/web/lib/components/search-form.tsx
+++ b/web/lib/components/search-form.tsx
@@ -93,7 +93,7 @@ const SearchForm = () => {
     const value = e.target.value
     const params = new URLSearchParams(searchParams.toString())
     params.set('filter', value)
-    if (value === 'hausdorff' ?? value === 'frechet') {
+    if (value === 'hausdorff' || value === 'frechet') {
       params.set('order', 'nearest_first')
     } else if (order === 'nearest_first') {
       params.set('order', 'newest_first')

--- a/web/lib/components/search-form.tsx
+++ b/web/lib/components/search-form.tsx
@@ -93,7 +93,7 @@ const SearchForm = () => {
     const value = e.target.value
     const params = new URLSearchParams(searchParams.toString())
     params.set('filter', value)
-    if (value === 'hausdorff' || value === 'frechet') {
+    if (value === 'hausdorff' ?? value === 'frechet') {
       params.set('order', 'nearest_first')
     } else if (order === 'nearest_first') {
       params.set('order', 'newest_first')

--- a/web/lib/components/tool-box.tsx
+++ b/web/lib/components/tool-box.tsx
@@ -37,11 +37,11 @@ const ToolBox = (props) => {
   const [mainState, dispatchMain] = useMainContext()
   const [mapState] = useMapContext()
   const pathManager = mapState.pathManager
-  const selectedPath = pathManager?.getEncodedSelection() || null
+  const selectedPath = pathManager?.getEncodedSelection() ?? null
   const autoGeolocation = mainState.autoGeolocation
   const [location, setLocation] = useState('')
   const geocoder = useRef<google.maps.Geocoder>(null)
-  const length = pathManager?.get('length') || 0
+  const length = pathManager?.get('length') ?? 0
   const { map, marker, addPoint, downloadPath, uploadPath, clearPaths } = mapState
   const [confirmInfo, setConfirmInfo] = useState<ConfirmInfo>({ open: false })
   const showMarker = (pos) => {

--- a/web/lib/components/walk-editor.tsx
+++ b/web/lib/components/walk-editor.tsx
@@ -79,7 +79,7 @@ const WalkEditor = ({ mode }: { mode: 'update' | 'create' }) => {
   if (!currentUser) {
     unauthorized()
   }
-  const dataUser = users.find((u) => u.uid === currentUser.uid) || null
+  const dataUser = users.find((u) => u.uid === currentUser.uid) ?? null
   if (!config.openUserMode && !dataUser.admin) {
     forbidden()
   }
@@ -88,7 +88,7 @@ const WalkEditor = ({ mode }: { mode: 'update' | 'create' }) => {
       <Paper sx={{ width: '100%', textAlign: 'center', padding: 2 }}>
         <Typography variant="body1" color="error" >{state.error?.message}</Typography>
         <Form action={formAction} name="walk-form" ref={formRef}>
-          <input type="hidden" name="path" defaultValue={searchPath || item?.path} />
+          <input type="hidden" name="path" defaultValue={searchPath ?? item?.path} />
           <input type="hidden" name="id" defaultValue={item?.id} />
           <FormGroup row>
             <TextField type="date" name="date" defaultValue={item?.date} variant="standard" label="date" fullWidth />

--- a/web/lib/db/models.ts
+++ b/web/lib/db/models.ts
@@ -16,7 +16,7 @@ export const sequelize = new Sequelize(
   })
 
 export const EARTH_RADIUS = 6370986
-export const SRID = process.env.SRID || 4326
+export const SRID = process.env.SRID ?? 4326
 export const SRID_FOR_SIMILAR_SEARCH = Number(process.env.SRID_FOR_SIMILAR_SEARCH)
 
 type LineStringJson = {

--- a/web/lib/utils/item-fetcher.tsx
+++ b/web/lib/utils/item-fetcher.tsx
@@ -17,7 +17,7 @@ export function ItemFetcher() {
   const [getItemState, dispatchGetItem] = useActionState(getItemAction, initialGetItemState)
   const { updateIdToken, idToken } = useUserContext()
   const params = useParams()
-  const id = Number(params.id) || null
+  const id = Number(params.id) ?? null
   const [data, setData] = useData()
   useEffect(() => {
     let index = -1

--- a/web/lib/utils/path-manager.ts
+++ b/web/lib/utils/path-manager.ts
@@ -18,7 +18,7 @@ export default class PathManager extends google.maps.MVCObject {
   
   constructor(optOptions) {
     super()
-    const options = optOptions || {}
+    const options = optOptions ?? {}
     this.polylines = {}
 
     this.drawingManager = new google.maps.drawing.DrawingManager({

--- a/web/lib/utils/polygon-manager.ts
+++ b/web/lib/utils/polygon-manager.ts
@@ -8,7 +8,7 @@ export default class PolygonManager extends google.maps.MVCObject {
     super()
     this.polygons = {}
     this.cache = {}
-    const options = optOptions || {}
+    const options = optOptions ?? {}
     this.setValues(options)
   }
 

--- a/web/lib/utils/user-context.tsx
+++ b/web/lib/utils/user-context.tsx
@@ -26,7 +26,7 @@ export function UserContextProvider({ children }: { children: React.ReactNode })
     if (typeof document === 'undefined') return ''
     const value = `; ${document.cookie}`
     const parts = value.split(`; ${name}=`)
-    if (parts.length === 2) return parts.pop()?.split(';').shift() || ''
+    if (parts.length === 2) return parts.pop()?.split(';').shift() ?? ''
     return ''
   }
   const initialIdToken = getCookieValue('idToken')
@@ -40,7 +40,7 @@ export function UserContextProvider({ children }: { children: React.ReactNode })
       setIdToken('')
       return
     }
-    const newIdToken = await currentUser?.getIdToken() || ''
+    const newIdToken = await currentUser?.getIdToken() ?? ''
     const secure = location.protocol === 'https:' ? '; secure' : ''
     // Max-Ageを1時間に設定してトークンの有効期限を管理
     document.cookie = `idToken=${newIdToken}; path=/; samesite=strict${secure}; max-age=3600`


### PR DESCRIPTION
This pull request focuses on replacing the logical OR (`||`) operator with the nullish coalescing (`??`) operator across the codebase to ensure better handling of `null` and `undefined` values. This change improves code readability and aligns with modern JavaScript practices.

### Codebase-wide improvements:

#### Environment variable handling:
* Updated environment variable fallbacks to use `??` instead of `||` for improved handling of `null` and `undefined` values in `web/app/layout.tsx`. [[1]](diffhunk://#diff-5cbb541bbd45c6fac277c02c4458cedecb804a76f0e40906808fca4e0f5a194cL9-R10) [[2]](diffhunk://#diff-5cbb541bbd45c6fac277c02c4458cedecb804a76f0e40906808fca4e0f5a194cL41-R42)

#### Configuration and data handling:
* Replaced `||` with `??` in the `getConfig` function to ensure proper fallback values for configuration properties in `web/app/lib/walk-actions.ts`.
* Updated fallback logic for `props` values in `searchInternalAction` to use `??` for better nullish value handling in `web/app/lib/walk-actions.ts`. [[1]](diffhunk://#diff-475b9f6f84ae50d7cc463cac1069865e5c34e507f3c10a238b1ab7ee6000bf5dL99-R99) [[2]](diffhunk://#diff-475b9f6f84ae50d7cc463cac1069865e5c34e507f3c10a238b1ab7ee6000bf5dL169-R169) [[3]](diffhunk://#diff-475b9f6f84ae50d7cc463cac1069865e5c34e507f3c10a238b1ab7ee6000bf5dL228-R229)

#### Component rendering:
* Improved nullish checks for rendering logic in components like `ItemBox`, `BottomBar`, and `ElevationBox` to use `??` for default values in `web/lib/components`. [[1]](diffhunk://#diff-963cce96ca74d4c7b20f7f2a5fefb4cb15465fd59e31cb27ec4c36e173e31f35L86-R86) [[2]](diffhunk://#diff-23d57755f3e0340039122e8b7f0d31cfe719c96a2507e362dacb2abccab9d1e0L156-R160) [[3]](diffhunk://#diff-9140d3cb65694703e37f1f83c1fef26e575fca8e83fefce60f40223a076ea9e0L80-R80)

#### Utility functions and classes:
* Updated utility functions and classes such as `PathManager` and `ItemFetcher` to use `??` for default values, enhancing code clarity and robustness in `web/lib/utils`. [[1]](diffhunk://#diff-2ec0e49f661cec41bfeb0deead57b60b8f1013b47e255ffb6637455a6945b54eL20-R20) [[2]](diffhunk://#diff-1c936a4625e17c2ba2b403710cf1e086da7201d557f74d731186cb7c14de6721L21-R21)