### PR TITLE
fix data consistency

### DIFF
--- a/web/lib/components/walk-editor.test.tsx
+++ b/web/lib/components/walk-editor.test.tsx
@@ -5,7 +5,7 @@ import WalkEditor from './walk-editor'
 const mockUpdateIdToken = jest.fn()
 const mockDeleteSelectedPath = jest.fn()
 const mockRouterPush = jest.fn()
-const mockReset = jest.fn()
+const mockSetData = jest.fn()
 const mockSearchParams = {
   toString: jest.fn(() => 'param1=value1&param2=value2')
 }
@@ -35,8 +35,7 @@ jest.mock('../utils/config', () => ({
 jest.mock('../utils/data-context', () => ({
   useData: () => [
     { current: { id: '2', date: '2023-01-01', title: 'Test Walk', comment: 'Test comment', draft: true } },
-    ,
-    mockReset
+    mockSetData
   ],
 }))
 

--- a/web/lib/components/walk-editor.tsx
+++ b/web/lib/components/walk-editor.tsx
@@ -35,7 +35,7 @@ const WalkEditor = ({ mode }: { mode: 'update' | 'create' }) => {
   }
   const config = useConfig()
   const { updateIdToken, currentUser, users } = useUserContext()
-  const [data] = useData()
+  const [data, setData] = useData()
   let item: WalkT
   if (mode === 'update') {
     item = data.current
@@ -52,7 +52,7 @@ const WalkEditor = ({ mode }: { mode: 'update' | 'create' }) => {
     }
   }
   const [state, formAction, isPending] = useActionState(updateItemAction, initialState)
-  const [searchPath] = useQueryParam('path', withDefault(StringParam, ''));
+  const [searchPath] = useQueryParam('path', withDefault(StringParam, null));
   const [mapState] = useMapContext();
   const { deleteSelectedPath } = mapState;
   const handleSubmit = useCallback(() => {
@@ -67,6 +67,9 @@ const WalkEditor = ({ mode }: { mode: 'update' | 'create' }) => {
         })()
       } else if (state.id) {
         if (searchPath) deleteSelectedPath()
+        if (mode === 'update') {
+          setData({ rows: [] })
+        }
         router.push(idToShowUrl(state.id))
       }
     }

--- a/web/lib/utils/data-context.tsx
+++ b/web/lib/utils/data-context.tsx
@@ -19,14 +19,11 @@ const DataContext = createContext(null)
 
 export function DataProvider({ children }: { children: React.ReactNode }) {
   const [data, setData] = useState<DataT>(initialData)
-  const reset = () => {
-    setData(initialData)
-  }
   const setDataExternal = (d) => {
     setData({ ...data, ...d }) 
   }
   return (
-    <DataContext.Provider value={[data, setDataExternal, reset]}>
+    <DataContext.Provider value={[data, setDataExternal]}>
       {children}
     </DataContext.Provider>
   )

--- a/web/lib/utils/path-manager.ts
+++ b/web/lib/utils/path-manager.ts
@@ -264,7 +264,7 @@ export default class PathManager extends google.maps.MVCObject {
     if (this.selection) {
       this.set('length', google.maps.geometry.spherical.computeLength(this.selection.getPath()) / 1000)
     } else {
-      this.set('length', '')
+      this.set('length', 0)
     }
   }
 


### PR DESCRIPTION
This pull request introduces several updates to the `WalkEditor` component and its related files, focusing on improving state management and refining behavior for specific scenarios. The most notable changes include replacing the `reset` function with `setData`, modifying query parameter handling, and adjusting the behavior of the `PathManager` class.

### State Management Updates:
* [`web/lib/utils/data-context.tsx`](diffhunk://#diff-e84519626fffc58f04809bad526e7187f86927328bb06eb2ddf664757bcabe90L22-R26): Removed the `reset` function from the `DataProvider` and replaced it with an external `setData` function for more granular updates to the data state.
* [`web/lib/components/walk-editor.tsx`](diffhunk://#diff-f6a7bc7f771fc4409e8314cc21a74f25ea097d5f1d54e3ae1195b5ba98ad2dbdL38-R38): Updated the `useData` hook to provide both `data` and `setData`. Added logic to clear rows in `setData` when the `WalkEditor` is in update mode. [[1]](diffhunk://#diff-f6a7bc7f771fc4409e8314cc21a74f25ea097d5f1d54e3ae1195b5ba98ad2dbdL38-R38) [[2]](diffhunk://#diff-f6a7bc7f771fc4409e8314cc21a74f25ea097d5f1d54e3ae1195b5ba98ad2dbdR70-R72)

### Query Parameter Refinements:
* [`web/lib/components/walk-editor.tsx`](diffhunk://#diff-f6a7bc7f771fc4409e8314cc21a74f25ea097d5f1d54e3ae1195b5ba98ad2dbdL55-R55): Changed the default value for the `searchPath` query parameter from an empty string to `null` to better handle cases where the parameter is absent.

### Testing Adjustments:
* [`web/lib/components/walk-editor.test.tsx`](diffhunk://#diff-a6684c27a44cf90d47f011a35fa734db827ed27b2f394afe881a156a0a342cceL8-R8): Replaced `mockReset` with `mockSetData` in tests to align with the updated state management logic. [[1]](diffhunk://#diff-a6684c27a44cf90d47f011a35fa734db827ed27b2f394afe881a156a0a342cceL8-R8) [[2]](diffhunk://#diff-a6684c27a44cf90d47f011a35fa734db827ed27b2f394afe881a156a0a342cceL38-R38)

### Path Length Calculation:
* [`web/lib/utils/path-manager.ts`](diffhunk://#diff-1c936a4625e17c2ba2b403710cf1e086da7201d557f74d731186cb7c14de6721L267-R267): Modified the `PathManager` class to set the path length to `0` instead of an empty string when no selection exists, ensuring consistent data types.