### PR TITLE
do not expire cookies

### DIFF
--- a/web/lib/utils/user-context.tsx
+++ b/web/lib/utils/user-context.tsx
@@ -43,7 +43,7 @@ export function UserContextProvider({ children }: { children: React.ReactNode })
     const newIdToken = await currentUser?.getIdToken() ?? ''
     const secure = location.protocol === 'https:' ? '; secure' : ''
     // Max-Ageを1時間に設定してトークンの有効期限を管理
-    document.cookie = `idToken=${newIdToken}; path=/; samesite=strict${secure}; max-age=3600`
+    document.cookie = `idToken=${newIdToken}; path=/; samesite=strict${secure};`
     setIdToken(newIdToken)
   }, [currentUser])
   


### PR DESCRIPTION
This pull request includes a small change to the `UserContextProvider` function in `web/lib/utils/user-context.tsx`. The change removes the `max-age` attribute from the `idToken` cookie, which previously set the token's expiration to one hour.