### PR TITLE
fix city search error

### DIFF
--- a/web/lib/db/models.ts
+++ b/web/lib/db/models.ts
@@ -151,6 +151,7 @@ Area.init({
   the_geom: DataTypes.BLOB,
 }, {
   sequelize,
+  modelName: 'Area',
   timestamps: false,
   underscored: true,
 })


### PR DESCRIPTION
This pull request includes a minor update to the `Area` model in `web/lib/db/models.ts`. The change explicitly sets the `modelName` property to `'Area'` in the model initialization options.