### PR TITLE
fix distance box condition

### DIFF
--- a/web/lib/components/search-box.tsx
+++ b/web/lib/components/search-box.tsx
@@ -29,6 +29,7 @@ const SearchBox = () => {
   const { offset, count, rows } = data
   const [showDistance, setShowDistance] = useState(true)
   const searchParams = useSearchParams()
+  const filter = searchParams.get('filter') || ''
   const handleShowDistance = useCallback((e) => {
     setShowDistance(e.target.value === 'true')  
   }, [])
@@ -111,7 +112,7 @@ const SearchBox = () => {
             <TableCell sx={sxCell}><Typography variant="body2">title</Typography></TableCell>
             <TableCell sx={sxCell}>
               {
-                rows.length > 0 && rows[0].distance !== undefined ?
+                rows.length > 0 && (filter === 'hausdorff' || filter === 'frechet') ?
                   (
                     <Select value={showDistance} onChange={handleShowDistance}>
                       <MenuItem value="true"><Typography variant="body2">distance</Typography></MenuItem>


### PR DESCRIPTION
This pull request updates the `SearchBox` component to improve how the distance column is displayed based on the selected filter. The main change ensures that the distance selection dropdown is shown only when the filter is set to either 'hausdorff' or 'frechet', rather than just checking if the first row has a `distance` property.

Display logic improvements:

* Added a `filter` variable to read the current filter value from the search parameters, defaulting to an empty string if not present. (`web/lib/components/search-box.tsx`)
* Updated the condition for showing the distance selection dropdown: now it appears only if there are rows and the filter is 'hausdorff' or 'frechet', improving the accuracy of when the distance column is relevant. (`web/lib/components/search-box.tsx`)