### PR TITLE
fix distance value condition

### DIFF
--- a/web/lib/components/search-box.test.tsx
+++ b/web/lib/components/search-box.test.tsx
@@ -71,7 +71,7 @@ describe('SearchBox', () => {
   })
 
   it('calls router.replace when index is present in searchParams', () => {
-    const mockRows = [{ id: 1, uid: 'user1', date: '2023-01-01', title: 'Test Walk', distance: 5 }];
+    const mockRows = [{ id: 1, uid: 'user1', date: '2023-01-01', title: 'Test Walk', length: 5 }];
     (useData as jest.Mock).mockReturnValue([
       {
         offset: 0,

--- a/web/lib/components/search-box.tsx
+++ b/web/lib/components/search-box.tsx
@@ -150,7 +150,7 @@ const SearchBox = () => {
                 <TableCell sx={sxCell}><MuiLink href={idToShowUrl(item.id, searchParams)} component={Link} color="primary" underline="hover">{item.title}</MuiLink></TableCell>
                 <TableCell sx={sxCell}>
                   {
-                    showDistance && item.distance !== undefined ?
+                    showDistance && (filter === 'hausdorff' || filter === 'frechet')  ?
                       item.distance.toFixed(1) :
                       item.length.toFixed(1)
                   }


### PR DESCRIPTION
This pull request updates the logic for displaying the `distance` value in the `SearchBox` component. The change ensures that the `distance` is only shown when the selected filter is either `'hausdorff'` or `'frechet'`, instead of simply checking if the `distance` value is defined.

**Search result display logic:**

* Updated the conditional rendering in the `SearchBox` component so that `distance` is displayed only when the `filter` is `'hausdorff'` or `'frechet'`; otherwise, `length` is shown. (`web/lib/components/search-box.tsx`, [web/lib/components/search-box.tsxL153-R153](diffhunk://#diff-672e91519ac1a07a204bed562f3388dd8f28323bb26175a73523875f012c14b7L153-R153))