### PR TITLE
bump node to v24

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v5
       with:
-        node-version: '23.x'
+        node-version: '24.x'
     - name: Install dependencies
       run: npm ci
     - name: run eslint

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1
 
-FROM node:23-alpine AS base
+FROM node:24-alpine AS base
 
 # Install dependencies only when needed
 FROM base AS deps


### PR DESCRIPTION
This pull request updates the Node.js version used in both the CI workflow and the Docker build configuration to ensure the project uses the latest stable Node.js release. This helps keep dependencies up to date and may provide performance, security, and compatibility improvements.

Environment updates:

* Updated the Node.js version in `.github/workflows/run-test.yml` from `23.x` to `24.x` for CI jobs.
* Updated the base image in `web/Dockerfile` from `node:23-alpine` to `node:24-alpine`.