### PR TITLE
downgrade typescript to 5.8.3 to suppress warnings

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -29,7 +29,7 @@
         "react-markdown": "^10.1.0",
         "recharts": "^3.2.0",
         "sequelize": "^6.37.7",
-        "typescript": "^5.9.2",
+        "typescript": "^5.8.3",
         "use-query-params": "^2.2.1",
         "zod": "^3.25.67"
       },
@@ -16441,9 +16441,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/web/package.json
+++ b/web/package.json
@@ -32,7 +32,7 @@
     "react-markdown": "^10.1.0",
     "recharts": "^3.2.0",
     "sequelize": "^6.37.7",
-    "typescript": "^5.9.2",
+    "typescript": "^5.8.3",
     "use-query-params": "^2.2.1",
     "zod": "^3.25.67"
   },


### PR DESCRIPTION
This pull request downgrades the TypeScript dependency in the project from version 5.9.2 to 5.8.3. This affects both the `web/package.json` and `web/package-lock.json` files, ensuring the project uses the older TypeScript version for consistency and compatibility.

Dependency version update:

* Downgraded the `typescript` package from version 5.9.2 to 5.8.3 in `web/package.json` and `web/package-lock.json` to resolve compatibility or stability issues. [[1]](diffhunk://#diff-b861012a5dd72b8a9f3281b7cf09f5a779c98569d040b1bbc1db50f1b15e7cceL35-R35) [[2]](diffhunk://#diff-3ebf69f247f3231fd796e60555489b4a1ed684e3ad4cb0ace460a2ed07d53a95L32-R32) [[3]](diffhunk://#diff-3ebf69f247f3231fd796e60555489b4a1ed684e3ad4cb0ace460a2ed07d53a95L16444-R16446)