### PR TITLE
update tool box in show view

### DIFF
--- a/web/lib/components/tool-box.test.tsx
+++ b/web/lib/components/tool-box.test.tsx
@@ -5,6 +5,7 @@ import ToolBox from '@/lib/components/tool-box';
 import { MainContextProvider } from '@/lib/utils/main-context';
 import { MapContextProvider } from '@/lib/utils/map-context';
 import { ConfigProvider } from '@/lib/utils/config';
+import { useQueryParam } from 'use-query-params/dist/useQueryParam'
 
 // Test configuration
 const TEST_TIMEOUT = 10000;
@@ -304,7 +305,6 @@ describe('ToolBox Component', () => {
 
   it('disables edit and download buttons when no path is selected', () => {
     // Mock useQueryParam to return null (no selected path)
-    const { useQueryParam } = require('use-query-params/dist/useQueryParam');
     useQueryParam.mockReturnValueOnce([null, jest.fn()]);
     
     render(

--- a/web/lib/components/tool-box.tsx
+++ b/web/lib/components/tool-box.tsx
@@ -27,6 +27,9 @@ import { useMapContext } from '../utils/map-context'
 import { useMainContext } from '../utils/main-context'
 import ConfirmModal, { APPEND_PATH_CONFIRM_INFO } from './confirm-modal'
 import { useConfig } from '../utils/config'
+import { useQueryParam } from 'use-query-params/dist/useQueryParam'
+import { withDefault } from 'serialize-query-params/dist/withDefault'
+import { StringParam } from 'serialize-query-params/dist/params'
 
 const AUTO_GEOLOCATION_INTERVAL = 60000
 
@@ -39,7 +42,7 @@ const ToolBox = (props) => {
   const [mainState, dispatchMain] = useMainContext()
   const [mapState] = useMapContext()
   const pathManager = mapState.pathManager
-  const selectedPath = pathManager?.getEncodedSelection() ?? null
+  const [selectedPath] = useQueryParam('path', withDefault(StringParam, null));
   const autoGeolocation = mainState.autoGeolocation
   const [location, setLocation] = useState('')
   const geocoder = useRef<google.maps.Geocoder>(null)


### PR DESCRIPTION
This pull request updates how the selected path is managed in the `ToolBox` component, switching from internal state to using a query parameter for improved synchronization with the URL.

Query parameter integration:

* Replaced the previous method of getting the selected path from `pathManager` with the `useQueryParam` hook, allowing the selected path to be read directly from the URL query parameter.
* Added imports for `useQueryParam`, `withDefault`, and `StringParam` to support query parameter handling in `tool-box.tsx`.