### PR TITLE
retain path after update

### DIFF
--- a/web/lib/components/walk-editor.tsx
+++ b/web/lib/components/walk-editor.tsx
@@ -109,9 +109,11 @@ const WalkEditor = ({ mode }: { mode: 'update' | 'create' }) => {
       } else if (state.id) {
         // フォーム送信が成功したらdirtyフラグをリセット
         dispatchMain({ type: 'SET_IS_DIRTY', payload: false })
-        if (searchPath) deleteSelectedPath()
+        
         if (mode === 'update') {
           setData({ rows: [] })
+        } else if (searchPath) {
+          deleteSelectedPath()
         }
         router.push(idToShowUrl(state.id))
       }


### PR DESCRIPTION
This pull request makes a minor adjustment to the logic for resetting the selected path after a successful form submission in the `WalkEditor` component. The main change is to ensure that `deleteSelectedPath()` is only called when in 'create' mode and a `searchPath` exists, rather than always calling it if `searchPath` is present.

- Improved conditional logic in `WalkEditor` to only call `deleteSelectedPath()` when in 'create' mode and `searchPath` exists, preventing unintended deletion during updates.