### PR TITLE
fix adjacent items

### DIFF
--- a/web/lib/components/walk-editor.tsx
+++ b/web/lib/components/walk-editor.tsx
@@ -111,7 +111,9 @@ const WalkEditor = ({ mode }: { mode: 'update' | 'create' }) => {
         dispatchMain({ type: 'SET_IS_DIRTY', payload: false })
         
         if (mode === 'update') {
-          setData({ rows: [] })
+          const index = data.rows.findIndex((row) => row?.id === item.id)
+          data.rows[index].stale = true
+          setData({ rows: data.rows })
         } else if (searchPath) {
           deleteSelectedPath()
         }

--- a/web/lib/utils/item-fetcher.tsx
+++ b/web/lib/utils/item-fetcher.tsx
@@ -24,9 +24,9 @@ export function ItemFetcher() {
     if (id !== null) {
       index = data.rows.findIndex((row) => row.id === id)
     }
-    if (index >= 0) {
+    if (index >= 0 && !data.rows[index].stale) {
       const newData: Partial<DataT> = {}
-      newData.index = index
+      newData.index = index 
       newData.prevId = index > 0 ? data.rows[index - 1].id : null
       newData.nextId = index < data.rows.length - 1 ? data.rows[index + 1].id : null
       newData.current = data.rows[index]
@@ -48,8 +48,22 @@ export function ItemFetcher() {
       })
       return
     }
-
-    const newData = { isPending, ...getItemState,  }
+    let index = -1
+    if (id !== null) {
+      index = data.rows.findIndex((row) => row.id === id)
+    }
+    const newData: Partial<DataT> = { isPending }
+    if (index >= 0) {
+      data.rows[index] = getItemState.current
+      newData.rows = data.rows
+      newData.current = getItemState.current
+      newData.index = index
+    } else {
+      newData.current = getItemState.current
+      newData.prevId = null
+      newData.nextId = null
+      newData.offset = 0
+    } 
     setData(newData)
   }, [getItemState.serial, isPending])
 

--- a/web/types.ts
+++ b/web/types.ts
@@ -28,6 +28,7 @@ export type WalkT = {
   path?: string
   image?: string
   draft?: boolean
+  stale?: boolean
 }
 
 export type SearchState ={


### PR DESCRIPTION
This pull request introduces a mechanism for marking data rows as "stale" and updates the logic for handling and fetching items accordingly. The main goal is to ensure that outdated or modified rows are properly flagged and handled throughout the UI and data-fetching logic.

Key changes include:

### Data Model Update

* Added a new optional `stale` property to the `WalkT` type in `web/types.ts` to indicate if a row is outdated.

### Marking Items as Stale

* Updated the `WalkEditor` component to mark a row as `stale` instead of resetting the data when updating an item, ensuring the UI can react to outdated rows.

### Fetching and Handling Stale Items

* Modified `ItemFetcher` to skip over rows marked as `stale` when searching for items by ID, preventing outdated data from being processed.
* Updated `ItemFetcher` to replace the current row with the latest item state and update the data structure accordingly, ensuring consistency after changes.