### PR TITLE
add appleWebApp to metadata

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -42,7 +42,7 @@ export const metadata: Metadata = {
     default: process.env.SITE_NAME ?? 'Walklog',
   },
   appleWebApp: {
-    title: 'Walklog',
+    title: process.env.SITE_NAME ?? 'Walklog',
     capable: true,
     statusBarStyle: 'black-translucent',
   },


### PR DESCRIPTION
This pull request adds Apple web app metadata to enhance the user experience when the site is added to the home screen on iOS devices.

Web app integration improvements:

* Added the `appleWebApp` property to the `metadata` object in `layout.tsx`, enabling web app capabilities, setting a custom title, and specifying a translucent black status bar style for iOS devices.