### PR TITLE
move to package.json

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -58,5 +58,13 @@
     "jest-environment-jsdom": "^30.2.0",
     "jest-fixed-jsdom": "^0.0.11",
     "typescript": "^5.8.3"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@firebase/util",
+      "protobufjs",
+      "sharp",
+      "unrs-resolver"
+    ]
   }
 }

--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -1,5 +1,0 @@
-onlyBuiltDependencies:
-  - '@firebase/util'
-  - protobufjs
-  - sharp
-  - unrs-resolver


### PR DESCRIPTION
This pull request updates how the `onlyBuiltDependencies` configuration is managed for the project. The configuration, which specifies dependencies that should be built, has been moved from the `pnpm-workspace.yaml` file into the `package.json` file. This centralizes dependency configuration and aligns with best practices for pnpm-managed monorepos.

**Dependency configuration changes:**

* Moved the `onlyBuiltDependencies` list (including `@firebase/util`, `protobufjs`, `sharp`, and `unrs-resolver`) from `pnpm-workspace.yaml` to the `pnpm` section of `package.json` for better maintainability and clarity. [[1]](diffhunk://#diff-b861012a5dd72b8a9f3281b7cf09f5a779c98569d040b1bbc1db50f1b15e7cceR61-R68) [[2]](diffhunk://#diff-4829df35b6769af4754c8828787c50751323324ffd3bac1e598fe985b056c947L1-L5)