### PR TITLE
fix pnpm version to 10.20.0

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -59,6 +59,7 @@
     "jest-fixed-jsdom": "^0.0.11",
     "typescript": "^5.8.3"
   },
+  "packageManager": "pnpm@10.20.0",
   "pnpm": {
     "onlyBuiltDependencies": [
       "@firebase/util",


### PR DESCRIPTION
This pull request makes a minor update to the `package.json` file by specifying the package manager and its version. This helps ensure consistent dependency management across different environments.

* Added the `"packageManager": "pnpm@10.20.0"` field to `package.json` to explicitly set the package manager and version.