### PR TITLE
Fix/remove duplicated v from version

### DIFF
--- a/web/lib/components/tool-box.test.tsx
+++ b/web/lib/components/tool-box.test.tsx
@@ -66,7 +66,7 @@ const mockMainContext = [
 ]
 
 const mockConfig = {
-  appVersion: '1.0.0',
+  appVersion: 'v1.0.0',
   googleApiKey: 'mock_api_key',
   mapTypeIds: 'roadmap,hybrid',
 }

--- a/web/lib/components/tool-box.tsx
+++ b/web/lib/components/tool-box.tsx
@@ -47,7 +47,7 @@ const ToolBox = (props) => {
   const geocoder = useRef<google.maps.Geocoder>(null)
   const length: number = (pathManager?.get('length') as number) ?? 0
   const config = useConfig()
-  const appVersion = `v${config.appVersion}`
+  const appVersion = config.appVersion
   const { map, marker, addPoint, downloadPath, uploadPath, clearPaths } =
         mapState
   const [confirmInfo, setConfirmInfo] = useState<ConfirmInfo>({


### PR DESCRIPTION
This pull request makes a minor update to how the app version is handled in the `ToolBox` component and its associated test. The main change is to ensure the `appVersion` string is consistently formatted without adding a redundant `'v'` prefix.

* Test and config changes:
  * Updated `mockConfig.appVersion` in `tool-box.test.tsx` to include the `'v'` prefix directly, so it's now `'v1.0.0'` instead of `'1.0.0'`.

* Component logic:
  * Modified `ToolBox` in `tool-box.tsx` to use `config.appVersion` directly, removing the code that prepended `'v'` to the version string.