### PR TITLE
show r2 errors

### DIFF
--- a/web/app/lib/walk-actions.ts
+++ b/web/app/lib/walk-actions.ts
@@ -547,6 +547,7 @@ export const updateItemAction = async (
     try {
       uploadedImage = await _saveImage(newImageFile, key)
     } catch (error) {
+      console.error('updateItemAction saveImage error', error)
       state.error = error as Error
       return state
     }

--- a/web/lib/utils/image-storage/r2.ts
+++ b/web/lib/utils/image-storage/r2.ts
@@ -20,8 +20,9 @@ export const saveR2 = async (file: File, key: string): Promise<string> => {
     headers: { 'Content-Type': file.type || 'application/octet-stream' },
   })
   if (!response.ok) {
+    const body = await response.text()
     throw new Error(
-      `Failed to upload to R2: ${response.status} ${response.statusText}`,
+      `Failed to upload to R2: ${response.status} ${response.statusText} ${body}`,
     )
   }
   return `${process.env.R2_PUBLIC_URL}/${key}`


### PR DESCRIPTION
This pull request introduces improvements to error handling and debugging for image upload functionality. The main changes enhance error logging and provide more detailed error messages when uploads to R2 fail.

**Error handling and debugging improvements:**

* Added a `console.error` log in `updateItemAction` to capture errors from `_saveImage`, making it easier to debug image upload issues (`web/app/lib/walk-actions.ts`).
* Enhanced the error message in `saveR2` to include the response body when an upload fails, giving more context for troubleshooting failed uploads (`web/lib/utils/image-storage/r2.ts`).