### PR TITLE
add body length to header

### DIFF
--- a/web/lib/utils/image-storage/r2.ts
+++ b/web/lib/utils/image-storage/r2.ts
@@ -17,12 +17,19 @@ export const saveR2 = async (file: File, key: string): Promise<string> => {
   const response = await getClient().fetch(getObjectUrl(key), {
     method: 'PUT',
     body,
-    headers: { 'Content-Type': file.type || 'application/octet-stream' },
+    headers: {
+      'Content-Type': file.type || 'application/octet-stream',
+      // aws4fetch treats Content-Length as unsignable and leaves it to the
+      // runtime's fetch to set from the body; Next.js's patched fetch in
+      // production builds doesn't always do so, which R2 then rejects with
+      // 411 Length Required. Set it explicitly to sidestep that.
+      'Content-Length': String(body.byteLength),
+    },
   })
   if (!response.ok) {
-    const body = await response.text()
+    const errorBody = await response.text()
     throw new Error(
-      `Failed to upload to R2: ${response.status} ${response.statusText} ${body}`,
+      `Failed to upload to R2: ${response.status} ${response.statusText} ${errorBody}`,
     )
   }
   return `${process.env.R2_PUBLIC_URL}/${key}`


### PR DESCRIPTION
This pull request addresses an upload issue with R2 storage by ensuring the `Content-Length` header is explicitly set when uploading files. This change improves compatibility with Next.js's fetch implementation, which sometimes omits this header, causing uploads to fail.

**Bug fix for file uploads to R2:**

* [`web/lib/utils/image-storage/r2.ts`](diffhunk://#diff-50945ed10eae77d6074361589331133596ecb81fdeeb989634b89373f17e8880L20-R32): Explicitly sets the `Content-Length` header based on the file body size to prevent R2 from rejecting uploads with a 411 Length Required error. This works around a Next.js fetch issue in production.