### PR TITLE
getConfig: fsベースのフォールバックを静的JSON importに置き換え

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -50,8 +50,6 @@ RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 
 COPY --from=builder /app/public ./public
-COPY --from=builder /app/default-shape-styles.json ./default-shape-styles.json
-COPY --from=builder /app/default-theme.json ./default-theme.json
 
 # Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing

--- a/web/app/lib/walk-actions.test.ts
+++ b/web/app/lib/walk-actions.test.ts
@@ -1,5 +1,6 @@
 import { eq, sql } from 'drizzle-orm'
-import fs from 'fs/promises'
+import defaultShapeStyles from '../../default-shape-styles.json'
+import defaultTheme from '../../default-theme.json'
 import { users, walks } from '../../lib/drizzle/schema'
 import { encode } from '../../lib/utils/path-encoder'
 
@@ -28,14 +29,6 @@ vi.mock('@/lib/utils/firebase-id-token', () => ({
   verifyFirebaseIdToken: vi.fn().mockResolvedValue({ uid: 'testUserId' }),
   IdTokenExpiredError: class IdTokenExpiredError extends Error {},
 }))
-
-vi.mock('fs/promises', () => {
-  const mockFs = {
-    writeFile: vi.fn(),
-    readFile: vi.fn(),
-  }
-  return { default: mockFs, ...mockFs }
-})
 
 // app/lib/walk-actions.ts talks to a real drizzle db instance. Rather than
 // mocking every query, swap it for a pglite (in-memory postgres + postgis)
@@ -956,15 +949,13 @@ describe('server actions', () => {
   })
 
   describe('getConfig', () => {
-    it('should return the correct configuration object', async () => {
-      const mockShapeStyles = { style: 'mockStyle' }
-      const mockTheme = { palette: {} }
-      ;(fs.readFile as Mock).mockImplementation((path) => {
-        if (path === './default-shape-styles.json') {
-          return Buffer.from(JSON.stringify(mockShapeStyles))
-        }
-        return Buffer.from(JSON.stringify(mockTheme))
-      })
+    afterEach(() => {
+      delete process.env.SHAPE_STYLES_JSON_URL
+      delete process.env.THEME_JSON_URL
+      vi.unstubAllGlobals()
+    })
+
+    it('returns the bundled default shape styles and theme when no URL is configured', async () => {
       process.env.APP_VERSION = '1.2.3'
       process.env.FIREBASE_API_KEY = 'test-api-key'
       process.env.FIREBASE_AUTH_DOMAIN = 'test.firebaseapp.com'
@@ -985,15 +976,31 @@ describe('server actions', () => {
           apiKey: 'test-api-key',
           authDomain: 'test.firebaseapp.com',
         },
-        theme: mockTheme,
-        shapeStyles: mockShapeStyles,
+        theme: defaultTheme,
+        shapeStyles: defaultShapeStyles,
       })
     })
 
-    it('should throw an error if reading the file fails', async () => {
-      ;(fs.readFile as Mock).mockRejectedValue(new Error('File read error'))
+    it('fetches shape styles and theme from the configured URLs instead', async () => {
+      const mockShapeStyles = { style: 'mockStyle' }
+      const mockTheme = { palette: {} }
+      process.env.SHAPE_STYLES_JSON_URL =
+        'https://example.com/shape-styles.json'
+      process.env.THEME_JSON_URL = 'https://example.com/theme.json'
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async (url: string) => ({
+          json: async () =>
+            url === process.env.SHAPE_STYLES_JSON_URL
+              ? mockShapeStyles
+              : mockTheme,
+        })),
+      )
 
-      await expect(getConfig()).rejects.toThrow('File read error')
+      const result = await getConfig()
+
+      expect(result.shapeStyles).toEqual(mockShapeStyles)
+      expect(result.theme).toEqual(mockTheme)
     })
   })
 })

--- a/web/app/lib/walk-actions.ts
+++ b/web/app/lib/walk-actions.ts
@@ -12,7 +12,6 @@ import {
   SQL,
   sql,
 } from 'drizzle-orm'
-import fs from 'fs/promises'
 import moment from 'moment'
 import { nanoid } from 'nanoid'
 import { cacheTag, revalidateTag } from 'next/cache'
@@ -42,6 +41,8 @@ import {
   UserT,
   WalkT,
 } from '@/types'
+import defaultShapeStyles from '../../default-shape-styles.json'
+import defaultTheme from '../../default-theme.json'
 import { db } from '../../lib/drizzle/db'
 import { areas, coordinatesToWKT, users, walks } from '../../lib/drizzle/schema'
 import {
@@ -91,25 +92,24 @@ const asCityT = (area: AreaAttributes): CityT => {
 
 const readJsonConfig = async (
   url: string | undefined,
-  defaultLocalPath: string,
+  defaultValue: unknown,
 ): Promise<unknown> => {
   if (url) {
     const response = await fetch(url)
     return response.json()
   }
-  const content = await fs.readFile(defaultLocalPath)
-  return JSON.parse(content.toString())
+  return defaultValue
 }
 
 export const getConfig = async (): Promise<ConfigT> => {
   'use cache'
   const shapeStyles = (await readJsonConfig(
     process.env.SHAPE_STYLES_JSON_URL,
-    './default-shape-styles.json',
+    defaultShapeStyles,
   )) as ShapeStyles
   const theme = (await readJsonConfig(
     process.env.THEME_JSON_URL,
-    './default-theme.json',
+    defaultTheme,
   )) as Theme
   return {
     googleApiKey: process.env.GOOGLE_API_KEY,


### PR DESCRIPTION
## Summary
- Cloudflare Workers移行の準備として、`getConfig()`の`fs.readFile`によるデフォルトJSON読み込みを静的import(`default-shape-styles.json` / `default-theme.json`)に置き換え
- WorkersにはファイルシステムがないためこのままではCF Workers上で動かない。静的importならDocker/Workers両方で同じコードパスになる
- `SHAPE_STYLES_JSON_URL` / `THEME_JSON_URL`によるURL上書きの挙動は変更なし
- 不要になったDockerfileの個別JSONファイルCOPYを削除(Next.jsのビルドにバンドルされるため)

## Test plan
- [x] `npx vitest run` (132 tests) が通ることを確認
- [x] `npx tsc --noEmit` でtypecheckが通ることを確認
- [x] `npx biome check` でフォーマット/lintが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)