### PR TITLE
Manage the idToken cookie server-side as httpOnly

### DIFF
--- a/web/app/lib/walk-actions.test.ts
+++ b/web/app/lib/walk-actions.test.ts
@@ -16,12 +16,23 @@ vi.mock('next/cache', () => ({
 
 let mockIdTokenCookie: string | undefined
 
+const mockCookieSet = vi.fn(
+  (name: string, value: string, _options?: unknown) => {
+    if (name === 'idToken') mockIdTokenCookie = value
+  },
+)
+const mockCookieDelete = vi.fn((name: string) => {
+  if (name === 'idToken') mockIdTokenCookie = undefined
+})
+
 vi.mock('next/headers', () => ({
   cookies: vi.fn(async () => ({
     get: (name: string) =>
       name === 'idToken' && mockIdTokenCookie
         ? { value: mockIdTokenCookie }
         : undefined,
+    set: mockCookieSet,
+    delete: mockCookieDelete,
   })),
 }))
 
@@ -50,6 +61,7 @@ import { PGlite } from '@electric-sql/pglite'
 import { revalidateTag } from 'next/cache'
 import { Mock } from 'vitest'
 import {
+  clearIdTokenAction,
   deleteItemAction,
   getCityAction,
   getConfig,
@@ -59,6 +71,7 @@ import {
   getUsersAction,
   searchAction,
   searchInternalAction,
+  setIdTokenAction,
   updateItemAction,
 } from '@/app/lib/walk-actions'
 import {
@@ -947,6 +960,44 @@ describe('server actions', () => {
 
       expect(result.error).toBeNull()
       expect(result.id).toEqual(expect.any(Number))
+    })
+  })
+
+  describe('setIdTokenAction / clearIdTokenAction', () => {
+    it('verifies the token and sets it as an httpOnly cookie', async () => {
+      const result = await setIdTokenAction('a-valid-token')
+
+      expect(result.error).toBe(false)
+      expect(mockCookieSet).toHaveBeenCalledWith(
+        'idToken',
+        'a-valid-token',
+        expect.objectContaining({
+          httpOnly: true,
+          sameSite: 'strict',
+          path: '/',
+        }),
+      )
+      expect(mockIdTokenCookie).toBe('a-valid-token')
+    })
+
+    it('does not set the cookie when the token fails verification', async () => {
+      ;(verifyFirebaseIdToken as Mock).mockRejectedValueOnce(
+        new Error('invalid'),
+      )
+
+      const result = await setIdTokenAction('a-bad-token')
+
+      expect(result.error).toBe(true)
+      expect(mockCookieSet).not.toHaveBeenCalled()
+    })
+
+    it('deletes the cookie', async () => {
+      mockIdTokenCookie = 'token'
+
+      await clearIdTokenAction()
+
+      expect(mockCookieDelete).toHaveBeenCalledWith('idToken')
+      expect(mockIdTokenCookie).toBeUndefined()
     })
   })
 

--- a/web/app/lib/walk-actions.ts
+++ b/web/app/lib/walk-actions.ts
@@ -215,6 +215,34 @@ export const getSelfStatusAction = async (): Promise<SelfStatusT> => {
   return user.active ? 'active' : 'pending'
 }
 
+// A little under Firebase's 1-hour token lifetime, so the cookie never
+// outlives the token it holds.
+const ID_TOKEN_COOKIE_MAX_AGE = 55 * 60
+
+export const setIdTokenAction = async (
+  idToken: string,
+): Promise<{ error: boolean }> => {
+  try {
+    await verifyFirebaseIdToken(idToken)
+  } catch {
+    return { error: true }
+  }
+  const cookieStore = await cookies()
+  cookieStore.set('idToken', idToken, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'strict',
+    path: '/',
+    maxAge: ID_TOKEN_COOKIE_MAX_AGE,
+  })
+  return { error: false }
+}
+
+export const clearIdTokenAction = async (): Promise<void> => {
+  const cookieStore = await cookies()
+  cookieStore.delete('idToken')
+}
+
 export const searchInternalAction = async (
   props: SearchProps,
   uid: string,

--- a/web/lib/components/nav-bar.test.tsx
+++ b/web/lib/components/nav-bar.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react'
+import { onIdTokenChanged } from 'firebase/auth'
 import React from 'react'
 import '@testing-library/jest-dom'
 import { Mock } from 'vitest'
@@ -24,7 +25,7 @@ vi.mock('firebase/auth', () => ({
   GoogleAuthProvider: vi.fn(),
   signInWithPopup: vi.fn(),
   signOut: vi.fn(),
-  onAuthStateChanged: vi.fn(),
+  onIdTokenChanged: vi.fn(() => vi.fn()),
 }))
 
 vi.mock(
@@ -54,9 +55,11 @@ describe('NavBar', () => {
   const mockDispatchMain = vi.fn()
   const mockPushWithGuard = vi.fn(() => vi.fn())
   const mockSetCurrentUser = vi.fn()
+  const mockUpdateIdToken = vi.fn()
 
   beforeEach(() => {
     vi.clearAllMocks()
+    ;(onIdTokenChanged as Mock).mockReturnValue(vi.fn())
 
     ;(useMainContext as Mock).mockReturnValue([
       { overlay: false, toolBoxOpened: false },
@@ -67,6 +70,7 @@ describe('NavBar', () => {
     ;(useUserContext as Mock).mockReturnValue({
       currentUser: null,
       setCurrentUser: mockSetCurrentUser,
+      updateIdToken: mockUpdateIdToken,
     })
 
     ;(useConfig as Mock).mockReturnValue({
@@ -103,11 +107,23 @@ describe('NavBar', () => {
     ;(useUserContext as Mock).mockReturnValue({
       currentUser: { displayName: 'Test User', photoURL: 'test-url' },
       setCurrentUser: mockSetCurrentUser,
+      updateIdToken: mockUpdateIdToken,
     })
 
     render(<NavBar />)
     fireEvent.click(screen.getByTestId('account-button'))
     expect(screen.getByText(/Logged in as Test User/)).toBeInTheDocument()
     expect(screen.getByText('logout')).toBeInTheDocument()
+  })
+
+  it('syncs currentUser and the id token cookie whenever Firebase reports a token change', () => {
+    render(<NavBar />)
+    const listener = (onIdTokenChanged as Mock).mock.calls[0][1]
+    const fakeUser = { displayName: 'Test User' }
+
+    listener(fakeUser)
+
+    expect(mockSetCurrentUser).toHaveBeenCalledWith(fakeUser)
+    expect(mockUpdateIdToken).toHaveBeenCalled()
   })
 })

--- a/web/lib/components/nav-bar.tsx
+++ b/web/lib/components/nav-bar.tsx
@@ -11,7 +11,7 @@ import { initializeApp } from 'firebase/app'
 import {
   GoogleAuthProvider,
   getAuth,
-  onAuthStateChanged,
+  onIdTokenChanged,
   signInWithPopup,
   signOut,
 } from 'firebase/auth'
@@ -31,7 +31,8 @@ const NavBar = (props: React.ComponentProps<typeof AppBar>) => {
   const [accountAnchorEl, setAccountAnchorEl] = useState<HTMLElement | null>(
     null,
   )
-  const { currentUser, setCurrentUser, selfStatus } = useUserContext()
+  const { currentUser, setCurrentUser, selfStatus, updateIdToken } =
+    useUserContext()
   const canPost = selfStatus === 'active'
   const handleMenuOpen =
     (setter: typeof setAccountAnchorEl) =>
@@ -66,10 +67,15 @@ const NavBar = (props: React.ComponentProps<typeof AppBar>) => {
 
     initializeApp(config.firebaseConfig)
     provider.current = new GoogleAuthProvider()
-    onAuthStateChanged(getAuth(), (user) => {
+    // onIdTokenChanged (rather than onAuthStateChanged) also fires on
+    // Firebase's own silent background token refresh, not just sign-in/out,
+    // so the httpOnly session cookie gets renewed proactively instead of
+    // waiting for a request to fail with an expired token first.
+    return onIdTokenChanged(getAuth(), (user) => {
       setCurrentUser(user)
+      void updateIdToken()
     })
-  }, [config.firebaseConfig])
+  }, [config.firebaseConfig, updateIdToken])
   const closeAllMenus = () => {
     setAccountAnchorEl(null)
   }

--- a/web/lib/utils/user-context.tsx
+++ b/web/lib/utils/user-context.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { User as FirebaseUser } from 'firebase/auth'
+import { User as FirebaseUser, getAuth } from 'firebase/auth'
 import {
   createContext,
   useCallback,
@@ -8,7 +8,12 @@ import {
   useState,
 } from 'react'
 import { SelfStatusT, UserT } from '@/types'
-import { getSelfStatusAction, getUsersAction } from '../../app/lib/walk-actions'
+import {
+  clearIdTokenAction,
+  getSelfStatusAction,
+  getUsersAction,
+  setIdTokenAction,
+} from '../../app/lib/walk-actions'
 
 type UserContextT = {
   users: UserT[]
@@ -36,47 +41,42 @@ export function UserContextProvider({
   const [currentUser, setCurrentUser] = useState<
     FirebaseUser | null | undefined
   >(undefined)
-  const getCookieValue = (name: string) => {
-    if (typeof document === 'undefined') return ''
-    const value = `; ${document.cookie}`
-    const parts = value.split(`; ${name}=`)
-    if (parts.length === 2) return parts.pop()?.split(';').shift() ?? ''
-    return ''
-  }
-  const initialIdToken = getCookieValue('idToken')
-  const [idToken, setIdToken] = useState(initialIdToken)
+  // Can't read the idToken cookie here anymore now that it's httpOnly - it
+  // only ever serves as a trigger for effects elsewhere, so starting empty
+  // and letting the first auth callback populate it is fine.
+  const [idToken, setIdToken] = useState('')
   const [users, setUsers] = useState<UserT[]>([])
   const [selfStatus, setSelfStatus] = useState<SelfStatusT>('anonymous')
 
+  // Reads getAuth().currentUser directly rather than closing over the
+  // `currentUser` state: this is also called from the onIdTokenChanged
+  // listener on Firebase's own silent background token refresh, where the
+  // User object is mutated in place rather than replaced, so a stale React
+  // closure could hand back an already-expired token.
   const updateIdToken = useCallback(async () => {
-    if (!currentUser) {
-      const secure = location.protocol === 'https:' ? '; secure' : ''
-      document.cookie = `idToken=; path=/; samesite=strict${secure}; expires=Thu, 01 Jan 1970 00:00:00 GMT`
+    const user = getAuth().currentUser
+    if (!user) {
+      await clearIdTokenAction()
       setIdToken('')
       setSelfStatus('anonymous')
       return
     }
-    const newIdToken = (await currentUser?.getIdToken()) ?? ''
-    const secure = location.protocol === 'https:' ? '; secure' : ''
-    // Max-Ageを1時間に設定してトークンの有効期限を管理
-    document.cookie = `idToken=${newIdToken}; path=/; samesite=strict${secure};`
+    const newIdToken = (await user.getIdToken()) ?? ''
+    const { error } = await setIdTokenAction(newIdToken)
+    if (error) {
+      setIdToken('')
+      setSelfStatus('anonymous')
+      return
+    }
     setIdToken(newIdToken)
     setSelfStatus(await getSelfStatusAction())
-  }, [currentUser])
+  }, [])
 
   useEffect(() => {
     void (async () => {
       setUsers(await getUsersAction())
     })()
   }, [])
-  useEffect(() => {
-    if (currentUser === undefined) {
-      return
-    }
-    void (async () => {
-      await updateIdToken()
-    })()
-  }, [currentUser])
   return (
     <UserContext.Provider
       value={{


### PR DESCRIPTION
## Summary
- The Firebase ID token cookie was read/written directly via `document.cookie` on the client, so it could never be `httpOnly`. Two new server actions (`setIdTokenAction`/`clearIdTokenAction`) verify the token and set/clear the cookie server-side instead; `updateIdToken()` in `user-context.tsx` now calls these rather than touching `document.cookie` directly. The 5 existing call sites that retry on `idTokenExpired` (`searcher.tsx`, `item-fetcher.tsx`, `walk-editor.tsx`, `item-box.tsx`) are unaffected - `updateIdToken()` keeps the same signature.
- Cookie is now `httpOnly`, `sameSite: strict`, `secure` in production, with an explicit `maxAge` (55 min - a safety margin under Firebase's actual 1-hour token lifetime; previously unset despite a comment claiming otherwise).
- `nav-bar.tsx` switches from `onAuthStateChanged` to `onIdTokenChanged`, so Firebase's own silent background token refresh (~hourly) proactively refreshes the cookie instead of only refreshing reactively after a request already failed with an expired token.
- `updateIdToken()` now reads `getAuth().currentUser` directly instead of closing over React state, since Firebase mutates the same `User` object in place on a silent refresh rather than handing back a new reference - relying on the React closure would have silently missed those refreshes.

## Test plan
- [x] `pnpm typecheck`, `pnpm test` (136 tests, incl. new `setIdTokenAction`/`clearIdTokenAction` coverage), `pnpm lint` all pass
- [x] Drove the running app with Playwright against a local Postgres: homepage renders, anonymous menu state correct, login click reaches Firebase's real `signInWithPopup` without the new `onIdTokenChanged` wiring crashing anything, `document.cookie` never exposes the token at any point
- [ ] Couldn't complete a real Google sign-in in this environment (no live Firebase project here) - please click through login/logout once against the real project and confirm in DevTools → Application → Cookies that `idToken` shows `HttpOnly: true`

## Note (unrelated to this change)
While testing locally I found that `pnpm dev` now requires `CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE` to be set or it fails outright (`next.config.ts`'s `initOpenNextCloudflareForDev()` from the already-merged Cloudflare Workers work). Not touched here, but worth a follow-up since it'll surprise anyone running `pnpm dev` fresh without Cloudflare env set up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)