### PR TITLE
Don't require Hyperdrive local emulation for plain next dev

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,5 +1,3 @@
-import { PHASE_DEVELOPMENT_SERVER } from 'next/constants'
-
 const nextConfig = {
   experimental: {
     serverActions: {
@@ -11,17 +9,4 @@ const nextConfig = {
   output: 'standalone',
 }
 
-export default async (phase: string) => {
-  // Gives local server code access to local versions of Cloudflare bindings
-  // under `next dev`. Gated on the phase rather than left unconditional:
-  // @opennextjs/cloudflare's own dev-detection heuristic also fires during
-  // `next build` when `useCache` is enabled, which would otherwise pull
-  // wrangler/.dev.vars into the Docker build too.
-  if (phase === PHASE_DEVELOPMENT_SERVER) {
-    const { initOpenNextCloudflareForDev } = await import(
-      '@opennextjs/cloudflare'
-    )
-    await initOpenNextCloudflareForDev()
-  }
-  return nextConfig
-}
+export default nextConfig


### PR DESCRIPTION
## Summary
- `pnpm dev` currently fails outright with `no local hyperdrive connection string` unless `CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE` is set, because `next.config.ts`'s `initOpenNextCloudflareForDev()` eagerly tries to resolve every binding in `wrangler.jsonc` (including Hyperdrive, which can't be reached outside Cloudflare's network without it).
- The app never actually needs this locally: `lib/drizzle/db.ts` only calls `getCloudflareContext()` (the only thing this setup enables) when `CF_WORKERS=true`, which is never the case under plain `next dev` - only under the real Workers runtime or `pnpm run preview`/`deploy`, both of which get their bindings from the built worker's own entrypoint and are unaffected by this change.
- Removed the call entirely rather than working around it, since it provided no benefit for this codebase's architecture.

## Test plan
- [x] `pnpm typecheck`, `pnpm test` (132 tests), `pnpm lint` all pass
- [x] `pnpm dev` (against a local Postgres) now boots and serves the homepage with **no** `CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE` set - previously failed here
- [x] Docker's `next build` still succeeds
- [x] `opennextjs-cloudflare build` still succeeds (uses the built worker's own bootstrap, unaffected by this config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)