### PR TITLE
fix: retry search/item fetch and treat verification failures as retryable after idle tabs

### DIFF
--- a/web/lib/actions/walk-actions.test.ts
+++ b/web/lib/actions/walk-actions.test.ts
@@ -921,6 +921,28 @@ describe('server actions', () => {
       expect(result.id).toBeNull()
     })
 
+    it('treats other token verification failures as retryable too, instead of a permanent unauthorized', async () => {
+      mockIdTokenCookie = 'token'
+      ;(verifyFirebaseIdToken as Mock).mockRejectedValueOnce(
+        new Error('JWKS fetch failed'),
+      )
+      const prevState = {
+        serial: 0,
+        error: null,
+        id: null,
+        idTokenExpired: false,
+      }
+      const formData = new Map()
+
+      const result = await updateItemAction(
+        prevState,
+        formData as unknown as FormData,
+      )
+
+      expect(result.idTokenExpired).toBe(true)
+      expect(result.id).toBeNull()
+    })
+
     it('denies posting for a pending user (auto-provisioned on first login)', async () => {
       mockIdTokenCookie = 'token'
       const prevState = {

--- a/web/lib/actions/walk-actions.ts
+++ b/web/lib/actions/walk-actions.ts
@@ -185,11 +185,14 @@ const verifyIdToken = async (
   try {
     return await verifyFirebaseIdToken(idToken.value)
   } catch (error) {
-    if (error instanceof IdTokenExpiredError) {
-      state.idTokenExpired = true
-    } else {
-      state.error = error as Error
+    // Treat any verification failure as retryable, not just an expired
+    // token: transient failures (e.g. refetching Google's JWKS right after
+    // a long-idle tab wakes up) land here too, and should let the client
+    // refresh the token and retry rather than hit a permanent unauthorized.
+    if (!(error instanceof IdTokenExpiredError)) {
+      console.error('verifyIdToken failed', error)
     }
+    state.idTokenExpired = true
     return null
   }
 }

--- a/web/lib/utils/item-fetcher.test.tsx
+++ b/web/lib/utils/item-fetcher.test.tsx
@@ -1,0 +1,60 @@
+import { render, waitFor } from '@testing-library/react'
+import { useParams } from 'next/navigation'
+import React from 'react'
+import { Mock } from 'vitest'
+import { getItemAction } from '@/lib/actions/walk-actions'
+import { useData } from './data-context'
+import ItemFetcher from './item-fetcher'
+import { useUserContext } from './user-context'
+
+vi.mock('@/lib/actions/walk-actions', () => ({
+  getItemAction: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({
+  useParams: vi.fn(),
+}))
+
+vi.mock('./data-context', () => ({
+  useData: vi.fn(),
+}))
+
+vi.mock('./user-context', () => ({
+  useUserContext: vi.fn(),
+}))
+
+describe('ItemFetcher', () => {
+  const mockSetData = vi.fn()
+  const mockUpdateIdToken = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUpdateIdToken.mockResolvedValue(undefined)
+    ;(useParams as Mock).mockReturnValue({ id: '5' })
+    ;(useData as Mock).mockReturnValue([{ rows: [] }, mockSetData])
+    ;(useUserContext as Mock).mockReturnValue({
+      updateIdToken: mockUpdateIdToken,
+      idToken: '',
+    })
+  })
+
+  it('refreshes the id token and re-fetches the item when the token has expired, instead of getting stuck', async () => {
+    ;(getItemAction as Mock)
+      .mockResolvedValueOnce({ idTokenExpired: true, current: null, serial: 1 })
+      .mockResolvedValueOnce({
+        idTokenExpired: false,
+        current: { id: 5 },
+        serial: 2,
+      })
+
+    render(<ItemFetcher />)
+
+    await waitFor(() => expect(getItemAction).toHaveBeenCalledTimes(2))
+    expect(mockUpdateIdToken).toHaveBeenCalled()
+    await waitFor(() =>
+      expect(mockSetData).toHaveBeenCalledWith(
+        expect.objectContaining({ current: { id: 5 } }),
+      ),
+    )
+  })
+})

--- a/web/lib/utils/item-fetcher.tsx
+++ b/web/lib/utils/item-fetcher.tsx
@@ -44,14 +44,24 @@ export function ItemFetcher() {
     }
   }, [id, idToken])
 
+  // Kept separate from the setData effect below, and keyed only on `serial`
+  // (not `isPending`): retrying inside a startTransition makes `isPending`
+  // flicker before the retried dispatch itself lands, which would otherwise
+  // re-trigger this branch while `idTokenExpired` is still stale and fire
+  // duplicate retries.
   useEffect(() => {
-    if (getItemState.serial <= 0) {
-      return
-    }
-    if (getItemState.idTokenExpired) {
-      startTransition(async () => {
-        await updateIdToken()
+    if (getItemState.serial > 0 && getItemState.idTokenExpired) {
+      startTransition(() => {
+        void (async () => {
+          await updateIdToken()
+          dispatchGetItem(id)
+        })()
       })
+    }
+  }, [getItemState.serial])
+
+  useEffect(() => {
+    if (getItemState.serial <= 0 || getItemState.idTokenExpired) {
       return
     }
     const index = findIndexById(id)

--- a/web/lib/utils/searcher.test.tsx
+++ b/web/lib/utils/searcher.test.tsx
@@ -1,0 +1,81 @@
+import { render, waitFor } from '@testing-library/react'
+import { useSearchParams } from 'next/navigation'
+import React from 'react'
+import { Mock } from 'vitest'
+import { searchAction } from '@/lib/actions/walk-actions'
+import { useConfig } from './config'
+import { useData } from './data-context'
+import Searcher from './searcher'
+import { useUserContext } from './user-context'
+
+vi.mock('@/lib/actions/walk-actions', () => ({
+  searchAction: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: vi.fn(),
+}))
+
+vi.mock('./config', () => ({
+  useConfig: vi.fn(),
+}))
+
+vi.mock('./data-context', () => ({
+  useData: vi.fn(),
+}))
+
+vi.mock('./user-context', () => ({
+  useUserContext: vi.fn(),
+}))
+
+describe('Searcher', () => {
+  const mockSetData = vi.fn()
+  const mockUpdateIdToken = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUpdateIdToken.mockResolvedValue(undefined)
+    ;(useSearchParams as Mock).mockReturnValue(new URLSearchParams())
+    ;(useConfig as Mock).mockReturnValue({ defaultCenter: null })
+    ;(useData as Mock).mockReturnValue([
+      { rows: [], offset: 0, params: '' },
+      mockSetData,
+    ])
+    ;(useUserContext as Mock).mockReturnValue({
+      updateIdToken: mockUpdateIdToken,
+      idToken: '',
+    })
+  })
+
+  it('refreshes the id token and re-runs the search when the token has expired, instead of getting stuck on "Searching..."', async () => {
+    ;(searchAction as Mock)
+      .mockResolvedValueOnce({
+        rows: [],
+        count: 0,
+        offset: 0,
+        idTokenExpired: true,
+        index: -1,
+        serial: 1,
+        append: false,
+      })
+      .mockResolvedValueOnce({
+        rows: [{ id: 1 }],
+        count: 1,
+        offset: 0,
+        idTokenExpired: false,
+        index: -1,
+        serial: 2,
+        append: false,
+      })
+
+    render(<Searcher />)
+
+    await waitFor(() => expect(searchAction).toHaveBeenCalledTimes(2))
+    expect(mockUpdateIdToken).toHaveBeenCalled()
+    await waitFor(() =>
+      expect(mockSetData).toHaveBeenCalledWith(
+        expect.objectContaining({ rows: [{ id: 1 }] }),
+      ),
+    )
+  })
+})

--- a/web/lib/utils/searcher.tsx
+++ b/web/lib/utils/searcher.tsx
@@ -74,14 +74,24 @@ export function Searcher() {
     })
   }, [searchParams, idToken])
 
+  // Kept separate from the setData effect below, and keyed only on `serial`
+  // (not `isPending`): retrying inside a startTransition makes `isPending`
+  // flicker before the retried dispatch itself lands, which would otherwise
+  // re-trigger this branch while `idTokenExpired` is still stale and fire
+  // duplicate retries.
   useEffect(() => {
-    if (searchState.serial <= 0) {
-      return
-    }
-    if (searchState.idTokenExpired) {
-      startTransition(async () => {
-        await updateIdToken()
+    if (searchState.serial > 0 && searchState.idTokenExpired) {
+      startTransition(() => {
+        void (async () => {
+          await updateIdToken()
+          dispatchSearch(props)
+        })()
       })
+    }
+  }, [searchState.serial])
+
+  useEffect(() => {
+    if (searchState.serial <= 0 || searchState.idTokenExpired) {
       return
     }
 


### PR DESCRIPTION
## Summary
- ブラウザを長時間放置後にアクセスすると server action が401のまま固定化する/検索が「Searching...」で固まる不具合の修正。
- `verifyIdToken`: `IdTokenExpiredError` 以外の検証失敗(タブ復帰直後のJWKS再取得失敗など)も `idTokenExpired` としてリトライ可能な扱いにし、`unauthorized()` に直行しないようにした。
- `searcher.tsx` / `item-fetcher.tsx`: `idTokenExpired` 時に `updateIdToken()` 後、検索/アイテム取得アクションを明示的に再実行するようにした(`walk-editor.tsx` / `item-box.tsx` と同じパターン)。リトライ用のeffectは `isPending` の一時的な変化で再入しないよう `serial` のみに依存させている。

## Test plan
- [x] `pnpm test` (vitest) — 全139件パス(新規3件含む)
- [x] `pnpm typecheck`
- [x] `pnpm lint` (biome)

🤖 Generated with [Claude Code](https://claude.com/claude-code)